### PR TITLE
Added high(er) DPI scaling

### DIFF
--- a/background.js
+++ b/background.js
@@ -114,7 +114,7 @@ async function capture(port, tabId, scrollHeight) {
                         if (i === segments - 1) {
                             //last is likely not the full height
                             const remainder = scrollHeight % tabHeight;
-							/* If no scrolling, do not cut off. */
+                            /* If no scrolling, do not cut off. */
                             const cutOff = segments === 1 /*&& tabHeight>scrollHeight*/ ? 0 : tabHeight - remainder;
                             // context.drawImage(image, 0, cutOff, tabWidth, remainder, 0, tabHeight * i, tabWidth, remainder);
                             context.drawImage(image, 0, tabHeight * i - cutOff, tabWidth, tabHeight);
@@ -153,12 +153,12 @@ async function prePage() {
             max-width: 850px;
         }
         
-		/* Hide left history & Co. sidebar. */
+        /* Hide left history & Co. sidebar. */
         body.screenshotGpt > div > div > div:first-child {
             display: none;
         }
         
-		/* Show content area. */
+        /* Show content area. */
         body.screenshotGpt > div > div > div:last-child {
             padding-left: unset;
         }
@@ -166,18 +166,18 @@ async function prePage() {
         body.screenshotGpt main {
             display: block;
         }
-		
-		/* Bonus: Hide "Model: GPT-4" etc. top row. */
+        
+        /* Bonus: Hide "Model: GPT-4" etc. top row. */
         body.screenshotGpt main > div > div > div > div > div:first-child {
             display: none;
         }
         
-		/* Bonus: Hide text box area content. */
+        /* Bonus: Hide text box area content. */
         body.screenshotGpt main > div:last-child {
             display: none;
         }
-		
-		/* Bonus: Hide text box area outer. */
+        
+        /* Bonus: Hide text box area outer. */
         body.screenshotGpt main > div > div > div > div > div:last-child {
             display: none;
         }

--- a/background.js
+++ b/background.js
@@ -106,13 +106,13 @@ async function capture(port, tabId, scrollHeight) {
             
             const canvas = document.createElement("canvas");
             var context = canvas.getContext("2d");
-            canvas.width = Math.ceil(850 * dpr);
-            canvas.height = Math.ceil(scrollHeight * dpr);
+            canvas.width = Math.floor(850 * dpr);
+            canvas.height = Math.floor(scrollHeight * dpr);
             for (let i = segments - 1; i >= 0; i--) {
                 await new Promise((resolve) => {
                     var image = new Image();
-                    image.width = Math.ceil(tabWidth * dpr);
-                    image.height = Math.ceil(tabHeight * dpr);
+                    image.width = Math.floor(tabWidth * dpr);
+                    image.height = Math.floor(tabHeight * dpr);
                     image.onload = function () {
                         // context.drawImage(image, 0, 0, 850, tabHeight, 0, tabHeight * i, 850, tabHeight);
                         // console.log('image', image.width, image.height);
@@ -120,11 +120,11 @@ async function capture(port, tabId, scrollHeight) {
                             //last is likely not the full height
                             const remainder = scrollHeight % tabHeight;
                             /* If no scrolling, do not cut off. */
-                            const cutOff = segments === 1 ? 0 : Math.ceil((tabHeight - remainder) * dpr);
+                            const cutOff = segments === 1 ? 0 : Math.floor((tabHeight - remainder) * dpr);
                             // context.drawImage(image, 0, cutOff, tabWidth, remainder, 0, tabHeight * i, tabWidth, remainder);
-                            context.drawImage(image, 0, Math.ceil(tabHeight * i * dpr) - cutOff, Math.ceil(tabWidth*dpr), Math.ceil(tabHeight * dpr));
+                            context.drawImage(image, 0, Math.floor(tabHeight * i * dpr) - cutOff, Math.floor(tabWidth*dpr), Math.floor(tabHeight * dpr));
                         } else {
-                            context.drawImage(image, 0, Math.ceil(tabHeight * i * dpr), Math.ceil(tabWidth * dpr), Math.ceil(tabHeight * dpr));
+                            context.drawImage(image, 0, Math.floor(tabHeight * i * dpr), Math.floor(tabWidth * dpr), Math.floor(tabHeight * dpr));
                         }
                         // context.drawImage(image, 0, tabHeight * i, tabWidth, tabHeight);
                         resolve();

--- a/background.js
+++ b/background.js
@@ -88,6 +88,7 @@ async function capture(port, tabId, scrollHeight) {
     console.log('visible height', tab.height);
     console.log('max height', scrollHeight);
     console.log('segments', segments);
+    
     for (let i = 0; i < segments; i++) {
         images.push(await captureSegment(port, tabId, tab.height * i));
         await sleep(510);
@@ -98,16 +99,20 @@ async function capture(port, tabId, scrollHeight) {
         target: {tabId},
         args: [tab.width, tab.height, segments, images, scrollHeight],
         async function(tabWidth, tabHeight, segments, images, scrollHeight) {
+    
             // console.log('wtf', tabWidth, tabHeight);
+            
+            var dpr = window.devicePixelRatio; // E.g. "1.5" as a float.
+            
             const canvas = document.createElement("canvas");
             var context = canvas.getContext("2d");
-            canvas.width = 850;
-            canvas.height = scrollHeight;
+            canvas.width = Math.ceil(850 * dpr);
+            canvas.height = Math.ceil(scrollHeight * dpr);
             for (let i = segments - 1; i >= 0; i--) {
                 await new Promise((resolve) => {
                     var image = new Image();
-                    image.width = tabWidth;
-                    image.height = tabHeight;
+                    image.width = Math.ceil(tabWidth * dpr);
+                    image.height = Math.ceil(tabHeight * dpr);
                     image.onload = function () {
                         // context.drawImage(image, 0, 0, 850, tabHeight, 0, tabHeight * i, 850, tabHeight);
                         // console.log('image', image.width, image.height);
@@ -115,11 +120,11 @@ async function capture(port, tabId, scrollHeight) {
                             //last is likely not the full height
                             const remainder = scrollHeight % tabHeight;
                             /* If no scrolling, do not cut off. */
-                            const cutOff = segments === 1 /*&& tabHeight>scrollHeight*/ ? 0 : tabHeight - remainder;
+                            const cutOff = segments === 1 ? 0 : Math.ceil((tabHeight - remainder) * dpr);
                             // context.drawImage(image, 0, cutOff, tabWidth, remainder, 0, tabHeight * i, tabWidth, remainder);
-                            context.drawImage(image, 0, tabHeight * i - cutOff, tabWidth, tabHeight);
+                            context.drawImage(image, 0, Math.ceil(tabHeight * i * dpr) - cutOff, Math.ceil(tabWidth*dpr), Math.ceil(tabHeight * dpr));
                         } else {
-                            context.drawImage(image, 0, tabHeight * i, tabWidth, tabHeight);
+                            context.drawImage(image, 0, Math.ceil(tabHeight * i * dpr), Math.ceil(tabWidth * dpr), Math.ceil(tabHeight * dpr));
                         }
                         // context.drawImage(image, 0, tabHeight * i, tabWidth, tabHeight);
                         resolve();


### PR DESCRIPTION
While the screenshots were already taken with correct scaling, they were scaled down to 850 pixels when drawing to the canvas.

I've added multiplications with [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) for drawing to the canvas.

- Tested successfully on my 150% display (`window.devicePixelRatio` returned `1.5`) physical Windows 11 machine. 
- Also tested successfully in a VMware Workstation Windows 10 machine where I manually set the scaling to 100%.